### PR TITLE
 use the same debug param in child process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - "4"
   - "6"
   - "8"
+  - "9"
+  - "10"
 
 branches:
  only:

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -74,14 +74,15 @@ function start(hook, run, opts) {
     var options = {};
 
     var debugParam = (function (array, contains) {
-      return contains.some(function (el) {
+      for (var i=0,len=contains.length;i<len;i++) {
+        var el = contains[i];
         for (var param of array) {
           if (param.indexOf(el) >=0) {
             return el;
           }
         }
         return null;
-      });
+      }
     })(process.execArgv, [
       '--inspect',
       '--inspect-brk',

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -73,14 +73,14 @@ function start(hook, run, opts) {
 
     var options = {};
 
-    var isDebugMode = (function (array, contains) {
+    var debugParam = (function (array, contains) {
       return contains.some(function (el) {
         for (var param of array) {
           if (param.indexOf(el) >=0) {
-            return true;
+            return el;
           }
         }
-        return false;
+        return null;
       });
     })(process.execArgv, [
       '--inspect',
@@ -89,12 +89,12 @@ function start(hook, run, opts) {
       '--debug-brk'
     ]);
 
-    if (isDebugMode) {
+    if (debugParam) {
       // child inherits debugmode from parent, but then port is in-use
       // and crashes, fix:
       // use random debug port for child
       var random = Math.floor(Math.random() * 64511) + 1024;
-      options.execArgv = ['--debug=' + random];
+      options.execArgv = [debugParam + '=' + random];
     }
 
     child = childRef._child = child_process.fork(run.script, [], options);


### PR DESCRIPTION
When you use the latest node, it use `--inspect` parameter to start a debug process, but in mocha-spawn, it use hard-coded `--debug` parameter. So when you use node 7+, it may break down in debug mode. 